### PR TITLE
Fix renderer showing minus sign on 00:00

### DIFF
--- a/src/renderer/pages/Countdown.vue
+++ b/src/renderer/pages/Countdown.vue
@@ -28,7 +28,7 @@
       }"
       :class="timerOpacity"
     >
-      {{ settings.show.minusSignOnExtra && update.isCountingUp && !update.isReset ? '-' : '' }}{{ timer }}
+      {{ settings.show.minusSignOnExtra && update.isCountingUp && !update.isReset && update.currentSeconds !== 0 ? '-' : '' }}{{ timer }}
     </div>
     <progress-bar
       v-if="settings.show.progress && ((settings.contentAtReset === ContentAtReset.Full && update.isReset) || !update.isReset)"


### PR DESCRIPTION
### Issue
When "Stop timer at 0" and "Minus Sign on Extra" are enabled and the timer reaches 00:00, the renderer displays -00:00.

### Fix
Checking if current seconds are different from 0 on the renderer solves the issue.