### PR TITLE
Fix timer flicker when 'stop timer at 0' is enabled

### DIFF
--- a/src/main/Utilities/Timer.ts
+++ b/src/main/Utilities/Timer.ts
@@ -80,12 +80,12 @@ export class Timer {
 
   _timerTick() {
     this.seconds = this.seconds - 1;
-    this.timerTickCallback(this.seconds);
 
     if (this.seconds <= 0 && this.stopsAtZero) {
       this.seconds = 0;
-      this.timerTickCallback(0);
       this.pause();
     }
+
+    this.timerTickCallback(this.seconds);
   }
 }


### PR DESCRIPTION
### Issue

With stop timer at 0 enabled, the UI sometimes briefly shows 00:01 when the timer hits zero.
This happens because the callback gets called before checking if stopsAtZero is true.

### Fix
Reordered the logic. Now the callback function gets called after the if block.
