### PR TITLE
Fix pulse animation stopping at 00:00 when 'Stop timer at 0' is enabled

### DIFF
--- a/src/renderer/pages/Countdown.vue
+++ b/src/renderer/pages/Countdown.vue
@@ -212,11 +212,11 @@ onMounted(async () => {
 }
 
 .pulse-1 {
-  animation: pulse-1 var(--animation-duration) cubic-bezier(0.4, 0, 0.6, 1);
+  animation: pulse-1 var(--animation-duration) cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
 .pulse-2 {
-  animation: pulse-2 var(--animation-duration) cubic-bezier(0.4, 0, 0.6, 1);
+  animation: pulse-2 var(--animation-duration) cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
 @keyframes pulse-1 {


### PR DESCRIPTION
### Issue

When "Pulse at zero" is enabled together with "Stop timer at 0", the pulse animation only runs once.
Since the timer stops emitting updates at 0, the pulse-1 and pulse-2 classes are applied only once and the animation (which has a single iteration) doesn’t repeat.

### Fix

Made the pulse-1 and pulse-2 CSS animations infinite, so the pulse effect continues even when the timer is stopped at 0.